### PR TITLE
fix: forward configuration context to executor

### DIFF
--- a/src/executors/currents.impl.ts
+++ b/src/executors/currents.impl.ts
@@ -14,7 +14,11 @@ export default async function currentsExecutor(
 
   const result = await Promise.race([
     await runExecutor(
-      { project: context.projectName, target: options.cypressExecutor },
+      {
+        project: context.projectName,
+        target: options.cypressExecutor,
+        configuration: context.configurationName,
+      },
       { ...options, watch: false },
       context
     ),


### PR DESCRIPTION
Currently any `-c` flags don't get forwarded to the e2e call

For example, `nx run app-e2e:currents:ci` or `nx run app-e2e:currents -c ci`, the `ci` doesn't get forwarded to when currents call the `e2e` script.

If your `e2e` has configurations for `ci`, `dev` etc, these settings won't be properly applied.